### PR TITLE
Move redux-logger from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,13 @@
     "webpack-node-externals": "^1.5.4",
     "yarn": "^0.17.8"
   },
+  "optionalDependencies": {
+    "redux-logger": "^2.7.4"
+  },
   "dependencies": {
     "immutable": "^3.8.1",
     "react": "^15.4.1",
     "redux": "^3.6.0",
-    "redux-immutable": "^3.0.8",
-    "redux-logger": "^2.7.4"
+    "redux-immutable": "^3.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "istanbul": "^1.1.0-alpha.1",
     "lodash": "^4.17.2",
     "mocha": "^3.1.2",
-    "redux-logger": "^2.7.4",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
     "webpack": "^1.13.3",
@@ -52,6 +51,7 @@
     "immutable": "^3.8.1",
     "react": "^15.4.1",
     "redux": "^3.6.0",
-    "redux-immutable": "^3.0.8"
+    "redux-immutable": "^3.0.8",
+    "redux-logger": "^2.7.4"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,10 @@ const nodeExternals = require('webpack-node-externals');
 module.exports = {
   entry: './src/index.js',
   target: 'node',
-  externals: [nodeExternals()],
+  externals: [
+    nodeExternals(), {
+    "redux-logger": "redux-logger",
+  }],
   output: {
     path: path.join(__dirname, '/lib'),
     filename: 'index.js',


### PR DESCRIPTION
So this package is a dependency of js-accounts/react (I wonder why :P) and it has it's own dependency on redux-logger package which is missing when trying to get a compiled version of js-accounts/react.

Moved the package redux-logger to dependencies as opposed to devDependencies to resolve the issue.